### PR TITLE
Time limit on endpoint to delete product to node link

### DIFF
--- a/requests/product-requests.http
+++ b/requests/product-requests.http
@@ -3,6 +3,6 @@ DELETE {{baseUrl}}/remove_product_to_node_link
 Content-Type: application/json
 
 {
-  "product": 2,
+  "product": 339,
   "node": 7933801341
 }


### PR DESCRIPTION
Deletion of a product to node link is only allowed within a short amount of time (5 minutes) since its creation.